### PR TITLE
Move scroll reveal logic from vanilla JS to React useEffect

### DIFF
--- a/index.html
+++ b/index.html
@@ -1311,28 +1311,8 @@
           });
         });
 
-        // Scroll reveal — Intersection Observer
-        var prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        if (!prefersReduced) {
-          var revealObserver = new IntersectionObserver(function(entries) {
-            entries.forEach(function(entry) {
-              if (entry.isIntersecting) {
-                entry.target.classList.add('visible');
-                revealObserver.unobserve(entry.target);
-              }
-            });
-          }, { threshold: 0.15 });
-
-          document.querySelectorAll('.reveal, .reveal-stagger').forEach(function(el) {
-            revealObserver.observe(el);
-          });
-        } else {
-          // If reduced motion, make everything visible immediately
-          document.querySelectorAll('.reveal, .reveal-stagger').forEach(function(el) {
-            el.classList.add('visible');
-          });
-        }
+        // Scroll reveal is handled in React (Index.tsx useEffect) so it runs
+        // after the component mounts and DOM elements exist.
 
         // Header scroll state — transparent at top, solid on scroll
         var header = document.querySelector('.header');

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,6 +4,35 @@ import React, { useEffect } from 'react';
 const Index = () => {
   useEffect(() => {
     document.title = "SIG Solutions - Revenue Operations";
+
+    // Scroll reveal — IntersectionObserver must run after React renders
+    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const revealElements = document.querySelectorAll('.reveal, .reveal-stagger');
+
+    if (!prefersReduced) {
+      const revealObserver = new IntersectionObserver(function(entries) {
+        entries.forEach(function(entry) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            revealObserver.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.15 });
+
+      revealElements.forEach(function(el) {
+        revealObserver.observe(el);
+      });
+
+      return () => {
+        revealElements.forEach(function(el) {
+          revealObserver.unobserve(el);
+        });
+      };
+    } else {
+      revealElements.forEach(function(el) {
+        el.classList.add('visible');
+      });
+    }
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
Migrated the scroll reveal animation initialization from inline vanilla JavaScript in `index.html` to a React `useEffect` hook in `Index.tsx`. This ensures the IntersectionObserver is set up after React has rendered the DOM elements, preventing timing issues where elements might not exist when the observer is initialized.

## Key Changes
- **Removed** scroll reveal initialization from `index.html` (lines 1314-1336)
- **Added** scroll reveal logic to `Index.tsx` `useEffect` hook that runs after component mount
- **Implemented** proper cleanup function to unobserve elements when component unmounts
- **Preserved** all existing functionality:
  - IntersectionObserver with 0.15 threshold
  - Respects `prefers-reduced-motion` media query
  - Adds 'visible' class to trigger animations
  - Unobserves elements after they become visible

## Implementation Details
- The `useEffect` runs with an empty dependency array, ensuring it executes once after initial render
- Cleanup function properly unobserves all elements to prevent memory leaks
- Maintains the same animation behavior and accessibility considerations as the original implementation
- Resolves potential race conditions where vanilla JS might execute before React renders elements

https://claude.ai/code/session_01NLKQXUaEPjau9eBEhFB3qt