### PR TITLE
Fix deploy workflow to use Next.js output directory (out/)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: out
 
   deploy:
     needs: build


### PR DESCRIPTION
Next.js static export outputs to out/, not dist/ (Vite).

https://claude.ai/code/session_01NLKQXUaEPjau9eBEhFB3qt