### PR TITLE
Replace sectors served with client logos on navy background

### DIFF
--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -12,7 +12,7 @@ export default function Stats() {
   const isInView = useInView(ref, { once: true, margin: '-50px' });
 
   return (
-    <section ref={ref} className="bg-navy py-14 lg:py-16">
+    <section ref={ref} className="bg-navy pt-10 pb-14 lg:pt-12 lg:pb-16">
       <Container>
         <div className="grid grid-cols-2 gap-8 lg:grid-cols-4 lg:gap-12">
           {STATS.map((stat, i) => {

--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -2,14 +2,14 @@
 
 import { motion, useInView } from 'framer-motion';
 import { useRef } from 'react';
-import { Building2, Shield, Users, TrendingUp } from 'lucide-react';
 import Container from '@/components/ui/Container';
 
-const sectors = [
-  { icon: Building2, label: 'NGO & Advocacy' },
-  { icon: Shield, label: 'Insurance' },
-  { icon: Users, label: 'Legal' },
-  { icon: TrendingUp, label: 'Financial Services' },
+const clients = [
+  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', height: 'h-10 lg:h-12' },
+  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', height: 'h-8 lg:h-10' },
+  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', height: 'h-10 lg:h-12' },
+  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png', height: 'h-8 lg:h-10' },
+  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', height: 'h-9 lg:h-11' },
 ];
 
 export default function TrustBar() {
@@ -17,33 +17,33 @@ export default function TrustBar() {
   const isInView = useInView(ref, { once: true, margin: '-50px' });
 
   return (
-    <section ref={ref} className="border-y border-slate-100 bg-slate-50/50 py-8">
+    <section ref={ref} className="bg-navy pt-14 lg:pt-16 pb-0">
       <Container>
         <motion.p
           initial={{ opacity: 0 }}
           animate={isInView ? { opacity: 1 } : {}}
           transition={{ duration: 0.5 }}
-          className="mb-6 text-center text-xs font-medium uppercase tracking-widest text-slate-400"
+          className="mb-8 text-center text-xs font-medium uppercase tracking-widest text-slate-400"
         >
-          Sectors served
+          Trusted by
         </motion.p>
 
-        <div className="flex flex-wrap items-center justify-center gap-4 sm:gap-8">
-          {sectors.map((sector, i) => {
-            const Icon = sector.icon;
-            return (
-              <motion.div
-                key={sector.label}
-                initial={{ opacity: 0, y: 10 }}
-                animate={isInView ? { opacity: 1, y: 0 } : {}}
-                transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
-                className="flex items-center gap-2 rounded-lg border border-slate-200/60 bg-white px-4 py-2.5"
-              >
-                <Icon className="h-3.5 w-3.5 text-blue-600" />
-                <span className="text-xs font-medium text-slate-600">{sector.label}</span>
-              </motion.div>
-            );
-          })}
+        <div className="flex flex-wrap items-center justify-center gap-8 sm:gap-12 lg:gap-16">
+          {clients.map((client, i) => (
+            <motion.div
+              key={client.name}
+              initial={{ opacity: 0, y: 10 }}
+              animate={isInView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
+              className="flex items-center justify-center"
+            >
+              <img
+                src={client.src}
+                alt={client.name}
+                className={`${client.height} w-auto object-contain`}
+              />
+            </motion.div>
+          ))}
         </div>
       </Container>
     </section>


### PR DESCRIPTION
- Replace generic sector icons with actual client logos: TLU, Firearms Guardian, Free South Africa, Civil Society SA, Acorn Brokers
- Each logo individually sized to maintain visual balance
- Change TrustBar background to navy (bg-navy) to match Stats section
- Remove border/gap between TrustBar and Stats so they flow as one block
- TrustBar uses pt-only padding, Stats uses reduced top padding
- Label changed from "Sectors served" to "Trusted by"

https://claude.ai/code/session_01TgRZ6Pxu3PRoawqtiGYCjS