### PR TITLE
UI audit: rewrite hero, fix CTAs, overhaul trust logos, tighten copy

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -21,10 +21,10 @@ const contactDetails = [
 ];
 
 const trustPoints = [
-  'Structured initial assessment',
+  'Direct access to operations leadership',
   'Response within one business day',
-  '30-minute operational assessment',
-  'No-obligation evaluation',
+  '30-minute fit assessment, no obligation',
+  'No sales scripts, no junior hand-offs',
 ];
 
 export default function ContactPage() {
@@ -37,11 +37,11 @@ export default function ContactPage() {
             Contact
           </p>
           <h1 className="max-w-3xl font-heading text-3xl font-bold tracking-tight text-navy sm:text-4xl">
-            Operational Enquiry
+            Talk to us
           </h1>
-          <p className="mt-6 max-w-2xl text-slate-600 leading-relaxed">
-            Whether you are evaluating partners, replacing internal strain, or addressing
-            a broken revenue process, we will assess fit within one conversation.
+          <p className="mt-6 max-w-2xl text-sm text-slate-600 leading-relaxed">
+            You&apos;ll speak directly with an operations lead. No junior hand-offs, no
+            sales scripts. We&apos;ll assess fit in one conversation.
           </p>
         </div>
       </section>
@@ -53,10 +53,10 @@ export default function ContactPage() {
             {/* Contact form - primary */}
             <div>
               <h2 className="mb-2 font-heading text-xl font-bold text-navy">
-                Submit an Enquiry
+                Send us a message
               </h2>
               <p className="mb-8 text-sm text-slate-600">
-                Describe your operational requirements and our team will respond within one business day.
+                Tell us what you need. An operations lead will respond within one business day.
               </p>
               <ContactForm />
             </div>

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -23,9 +23,9 @@ export default function ContactForm() {
         <div className="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
           <Send className="h-4 w-4 text-green-600" />
         </div>
-        <h3 className="font-heading text-base font-bold text-navy">Enquiry Submitted</h3>
+        <h3 className="font-heading text-base font-bold text-navy">Received</h3>
         <p className="mt-2 text-sm text-slate-600">
-          Our team will respond within one business day.
+          An operations lead will respond within one business day.
         </p>
       </div>
     );
@@ -100,7 +100,7 @@ export default function ContactForm() {
           </>
         ) : (
           <>
-            Submit Enquiry
+            Send message
             <Send className="h-4 w-4" />
           </>
         )}

--- a/src/components/home/CTABanner.tsx
+++ b/src/components/home/CTABanner.tsx
@@ -20,17 +20,17 @@ export default function CTABanner() {
           transition={{ duration: 0.6 }}
           className="font-heading text-3xl font-bold tracking-tight text-white sm:text-4xl"
         >
-          Evaluate Operational Fit
+          Not sure if we&apos;re the right fit?
         </motion.h2>
 
         <motion.p
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.1 }}
-          className="mx-auto mt-6 max-w-2xl text-lg leading-relaxed text-slate-300"
+          className="mx-auto mt-6 max-w-2xl text-base leading-relaxed text-slate-300"
         >
-          If you are evaluating partners, replacing internal strain, or addressing
-          a broken revenue process, we will assess fit within one conversation.
+          One 30-minute call with an operations lead. No sales scripts. We&apos;ll
+          tell you honestly whether we can help.
         </motion.p>
 
         <motion.div
@@ -40,7 +40,7 @@ export default function CTABanner() {
           className="mt-10"
         >
           <Button href={CONTACT_URL} variant="primary" size="lg">
-            Request Operational Review
+            Talk to an operations lead
             <ArrowRight className="ml-2 h-4 w-4" />
           </Button>
         </motion.div>

--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -116,14 +116,14 @@ export default function FAQ() {
           className="mt-12 rounded-xl border border-slate-200 bg-slate-50 p-8 text-center"
         >
           <p className="font-heading text-lg font-bold text-navy">
-            Additional Questions
+            Have a specific question?
           </p>
           <p className="mt-2 text-sm text-slate-600">
-            Submit an enquiry and our team will respond within one business day.
+            Talk to our operations team directly. No scripts, no hand-offs.
           </p>
           <div className="mt-6">
             <Button href="/contact" variant="primary">
-              Submit Enquiry
+              Get in touch
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
           </div>

--- a/src/components/home/FloatingCTA.tsx
+++ b/src/components/home/FloatingCTA.tsx
@@ -34,7 +34,7 @@ export default function FloatingCTA() {
               href="/contact"
               className="flex w-full items-center justify-center rounded-lg bg-blue-600 px-6 py-3.5 font-heading text-sm font-semibold text-white shadow-lg shadow-blue-600/25 transition-all duration-200 hover:bg-blue-700 hover:shadow-blue-600/40 active:scale-[0.98]"
             >
-              Request Operational Review
+              See if we&apos;re a fit
               <ArrowRight className="ml-2 h-4 w-4" />
             </a>
           </div>

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { ArrowRight, ChevronDown } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import Container from '@/components/ui/Container';
 import Button from '@/components/ui/Button';
 import { CONTACT_URL } from '@/lib/data';
@@ -19,7 +19,7 @@ export default function Hero() {
   return (
     <section className="relative overflow-hidden bg-gradient-to-b from-slate-50 via-white to-white pt-32 pb-16 lg:pt-40 lg:pb-24">
       <Container className="relative">
-        <div className="max-w-4xl">
+        <div className="max-w-3xl">
           <motion.p
             custom={0}
             variants={fadeUp}
@@ -27,7 +27,7 @@ export default function Hero() {
             animate="visible"
             className="mb-4 font-heading text-sm font-semibold uppercase tracking-widest text-blue-600"
           >
-            BPO &amp; Revenue Operations
+            For NGOs, subscription businesses &amp; membership organisations
           </motion.p>
 
           <motion.h1
@@ -37,7 +37,7 @@ export default function Hero() {
             animate="visible"
             className="font-heading text-3xl font-bold leading-[1.15] tracking-tight text-navy sm:text-4xl lg:text-5xl"
           >
-            Performance-Driven BPO &amp; Revenue Operations Infrastructure
+            We run your sales, collections, and lead generation so you don&apos;t have to.
           </motion.h1>
 
           <motion.p
@@ -45,10 +45,10 @@ export default function Hero() {
             variants={fadeUp}
             initial="hidden"
             animate="visible"
-            className="mt-6 max-w-2xl text-lg leading-relaxed text-slate-600"
+            className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600"
           >
-            SIG Solutions operates where lead generation, outbound sales, and revenue
-            collection meet. We don&apos;t optimise parts. We run the whole.
+            50–100 trained agents in Pretoria handling outbound calls, payment recovery,
+            and lead qualification. You get consistent revenue. We handle the operations.
           </motion.p>
 
           <motion.div
@@ -59,12 +59,11 @@ export default function Hero() {
             className="mt-10 flex flex-wrap gap-4"
           >
             <Button href={CONTACT_URL} variant="primary" size="lg">
-              Request Operational Review
+              See if we&apos;re a fit
               <ArrowRight className="ml-2 h-4 w-4" />
             </Button>
             <Button href="/services" variant="outline" size="lg">
-              View Service Capabilities
-              <ChevronDown className="ml-2 h-4 w-4" />
+              View services
             </Button>
           </motion.div>
         </div>

--- a/src/components/home/HowWeWork.tsx
+++ b/src/components/home/HowWeWork.tsx
@@ -19,10 +19,10 @@ export default function HowWeWork() {
           className="mb-12 text-center"
         >
           <p className="mb-3 font-heading text-sm font-semibold uppercase tracking-widest text-blue-600">
-            Engagement Process
+            How it works
           </p>
           <h2 className="font-heading text-3xl font-bold tracking-tight text-navy sm:text-4xl">
-            How We Work
+            Four steps to operational delivery
           </h2>
         </motion.div>
 

--- a/src/components/home/ServicePillars.tsx
+++ b/src/components/home/ServicePillars.tsx
@@ -21,13 +21,13 @@ export default function ServicePillars() {
           className="mb-12 max-w-2xl"
         >
           <p className="mb-3 font-heading text-sm font-semibold uppercase tracking-widest text-blue-600">
-            Service Capabilities
+            What we run for you
           </p>
           <h2 className="font-heading text-3xl font-bold tracking-tight text-navy sm:text-4xl">
-            Core Service Pillars
+            Sales, collections, and lead generation
           </h2>
-          <p className="mt-4 text-slate-600">
-            Four integrated capabilities that cover the full revenue chain, from first click to collected payment.
+          <p className="mt-4 text-sm text-slate-600">
+            Two core services backed by specialist support.
           </p>
         </motion.div>
 
@@ -40,8 +40,13 @@ export default function ServicePillars() {
                 initial={{ opacity: 0, y: 30 }}
                 animate={isInView ? { opacity: 1, y: 0 } : {}}
                 transition={{ duration: 0.6, delay: 0.1 + i * 0.1 }}
-                className="rounded-xl border border-slate-200 bg-white p-8 lg:p-10"
+                className="relative rounded-xl border border-slate-200 bg-white p-8 lg:p-10"
               >
+                {i === 0 && (
+                  <span className="absolute top-4 right-4 rounded-full bg-blue-600 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-white">
+                    Most clients start here
+                  </span>
+                )}
                 <div className="mb-6 flex h-12 w-12 items-center justify-center rounded-lg bg-blue-50 text-blue-600">
                   <Icon className="h-6 w-6" />
                 </div>

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -37,6 +37,14 @@ export default function Stats() {
             );
           })}
         </div>
+        <motion.p
+          initial={{ opacity: 0 }}
+          animate={isInView ? { opacity: 1 } : {}}
+          transition={{ duration: 0.6, delay: 0.5 }}
+          className="mt-8 text-center text-xs text-slate-500"
+        >
+          Across subscription, fundraising, and outbound sales campaigns
+        </motion.p>
       </Container>
     </section>
   );

--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -5,11 +5,11 @@ import { useRef } from 'react';
 import Container from '@/components/ui/Container';
 
 const clients = [
-  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', height: 'h-10 lg:h-12' },
-  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', height: 'h-8 lg:h-10' },
-  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', height: 'h-10 lg:h-12' },
-  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png', height: 'h-8 lg:h-10' },
-  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', height: 'h-9 lg:h-11' },
+  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png' },
+  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png' },
+  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png' },
+  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png' },
+  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png' },
 ];
 
 export default function TrustBar() {
@@ -23,24 +23,44 @@ export default function TrustBar() {
           initial={{ opacity: 0 }}
           animate={isInView ? { opacity: 1 } : {}}
           transition={{ duration: 0.5 }}
-          className="mb-8 text-center text-xs font-medium uppercase tracking-widest text-slate-400"
+          className="mb-10 text-center text-xs font-medium uppercase tracking-widest text-slate-400"
         >
-          Trusted by
+          Trusted by organisations running high-volume outbound, fundraising, and recurring collections
         </motion.p>
 
-        <div className="flex flex-wrap items-center justify-center gap-8 sm:gap-12 lg:gap-16">
+        {/* Desktop: single row, large logos */}
+        <div className="hidden sm:flex items-center justify-center gap-14 lg:gap-20">
           {clients.map((client, i) => (
             <motion.div
               key={client.name}
               initial={{ opacity: 0, y: 10 }}
               animate={isInView ? { opacity: 1, y: 0 } : {}}
               transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
-              className="flex items-center justify-center"
+              className="flex items-center justify-center px-2"
             >
               <img
                 src={client.src}
                 alt={client.name}
-                className={`${client.height} w-auto object-contain`}
+                className="h-12 lg:h-14 w-auto max-w-[180px] object-contain brightness-0 invert opacity-80"
+              />
+            </motion.div>
+          ))}
+        </div>
+
+        {/* Mobile: 2 per row, large and legible */}
+        <div className="grid grid-cols-2 gap-8 sm:hidden">
+          {clients.map((client, i) => (
+            <motion.div
+              key={client.name}
+              initial={{ opacity: 0, y: 10 }}
+              animate={isInView ? { opacity: 1, y: 0 } : {}}
+              transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
+              className="flex items-center justify-center px-2 py-2"
+            >
+              <img
+                src={client.src}
+                alt={client.name}
+                className="h-10 w-auto max-w-full object-contain brightness-0 invert opacity-80"
               />
             </motion.div>
           ))}

--- a/src/components/home/WhySIG.tsx
+++ b/src/components/home/WhySIG.tsx
@@ -17,7 +17,7 @@ export default function WhySIG() {
           transition={{ duration: 0.6 }}
           className="mb-3 font-heading text-sm font-semibold uppercase tracking-widest text-blue-600"
         >
-          Operational Rationale
+          Why us
         </motion.p>
 
         <motion.h2
@@ -26,19 +26,8 @@ export default function WhySIG() {
           transition={{ duration: 0.6, delay: 0.1 }}
           className="font-heading text-3xl font-bold tracking-tight text-navy sm:text-4xl"
         >
-          Why SIG Solutions Exists
+          Your team can&apos;t do this at scale. Ours can.
         </motion.h2>
-
-        <motion.p
-          initial={{ opacity: 0, y: 20 }}
-          animate={isInView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.15 }}
-          className="mt-6 text-slate-600 leading-relaxed"
-        >
-          Internal teams struggle once volume increases. Lead generation,
-          sales execution, and collections each require dedicated operational
-          capacity that most organisations cannot sustain internally.
-        </motion.p>
 
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -47,9 +36,9 @@ export default function WhySIG() {
           className="my-10 rounded-xl border border-slate-200 bg-slate-50 p-8 lg:p-10"
         >
           <p className="font-heading text-lg font-bold leading-relaxed text-navy sm:text-xl">
-            Lead acquisition is straightforward.<br />
-            Sustained sales pressure is not.<br />
-            Collections are where most organisations lose revenue.
+            Getting leads is easy.<br />
+            Following up consistently is hard.<br />
+            Collecting payments at scale is where most organisations break.
           </p>
         </motion.div>
 
@@ -57,10 +46,10 @@ export default function WhySIG() {
           initial={{ opacity: 0, y: 20 }}
           animate={isInView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6, delay: 0.25 }}
-          className="text-slate-600 leading-relaxed"
+          className="text-sm text-slate-600 leading-relaxed"
         >
-          We take responsibility where most organisations lose control: the follow-ups that
-          don&apos;t happen, the payments that fail, and the systems that break under scale.
+          We own the follow-ups that don&apos;t happen, the payments that fail,
+          and the systems that break under volume. That&apos;s the job.
         </motion.p>
       </Container>
     </section>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,7 +31,10 @@ export default function Footer() {
               className="mb-4 h-[54px] brightness-0 invert"
             />
             <p className="text-sm text-slate-400">
-              Riviera, Pretoria<br />South Africa
+              Riviera, Pretoria, South Africa
+            </p>
+            <p className="mt-3 text-xs text-slate-500">
+              Direct access to operations leadership.<br />No junior hand-offs.
             </p>
           </div>
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -62,7 +62,7 @@ export default function Navbar() {
               href={CONTACT_URL}
               className="inline-flex items-center rounded-lg bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white shadow-lg shadow-blue-600/25 transition-all duration-200 hover:-translate-y-0.5 hover:bg-blue-700 hover:shadow-blue-600/40"
             >
-              Request Operational Review
+              Talk to our team
             </a>
           </nav>
 

--- a/src/components/services/ServiceDetail.tsx
+++ b/src/components/services/ServiceDetail.tsx
@@ -85,7 +85,7 @@ export default function ServiceDetail({
 
         <motion.div initial={{ opacity: 0, y: 20 }} animate={isInView ? { opacity: 1, y: 0 } : {}} transition={{ duration: 0.6, delay: 0.3 }} className="mt-10">
           <Button href={CONTACT_URL} variant="primary">
-            Enquire About This Service <ArrowRight className="ml-2 h-4 w-4" />
+            Discuss this service <ArrowRight className="ml-2 h-4 w-4" />
           </Button>
         </motion.div>
       </Container>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -345,6 +345,6 @@ export const FAQ_ITEMS = [
   },
   {
     question: 'How is pricing structured?',
-    answer: 'Pricing depends on the scope of services, team size, and campaign complexity. We offer transparent, performance-aligned pricing models. Book a strategy call to get a tailored proposal.',
+    answer: 'Pricing depends on the scope of services, team size, and campaign complexity. We offer transparent, performance-aligned pricing models. Get in touch for a tailored proposal.',
   },
 ];


### PR DESCRIPTION
- Hero: single clear sentence, audience anchor, grounded CTA "See if we're a fit"
- TrustBar: large white-on-navy logos, 2-per-row mobile, framing text
- Stats: added context line "Across subscription, fundraising, and outbound campaigns"
- Services: "Most clients start here" badge, clearer hierarchy
- CTAs: human language throughout ("Talk to our team", "See if we're a fit")
- WhySIG: shorter, more opinionated ("Your team can't do this at scale. Ours can.")
- Contact/Footer: reassurance about who answers, no junior hand-offs
- Text density reduced across all sections

https://claude.ai/code/session_01TgRZ6Pxu3PRoawqtiGYCjS