### PR TITLE
Precision fixes: reduce stat label size, tighten micro-copy

### DIFF
--- a/src/components/home/FAQ.tsx
+++ b/src/components/home/FAQ.tsx
@@ -119,7 +119,7 @@ export default function FAQ() {
             Have a specific question?
           </p>
           <p className="mt-2 text-sm text-slate-600">
-            Talk to our operations team directly. No scripts, no hand-offs.
+            Talk to our operations team directly. No scripts. No hand-offs.
           </p>
           <div className="mt-6">
             <Button href="/contact" variant="primary">

--- a/src/components/home/Hero.tsx
+++ b/src/components/home/Hero.tsx
@@ -48,7 +48,7 @@ export default function Hero() {
             className="mt-6 max-w-2xl text-base leading-relaxed text-slate-600"
           >
             50–100 trained agents in Pretoria handling outbound calls, payment recovery,
-            and lead qualification. You get consistent revenue. We handle the operations.
+            and lead qualification. You get consistent revenue. We handle the operations end-to-end.
           </motion.p>
 
           <motion.div

--- a/src/components/home/ServicePillars.tsx
+++ b/src/components/home/ServicePillars.tsx
@@ -27,7 +27,7 @@ export default function ServicePillars() {
             Sales, collections, and lead generation
           </h2>
           <p className="mt-4 text-sm text-slate-600">
-            Two core services backed by specialist support.
+            Core services backed by specialist support.
           </p>
         </motion.div>
 

--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -32,7 +32,7 @@ export default function Stats() {
                     suffix={stat.suffix}
                   />
                 </div>
-                <p className="mt-2 text-sm text-slate-400">{stat.label}</p>
+                <p className="mt-2 text-xs text-slate-400">{stat.label}</p>
               </motion.div>
             );
           })}


### PR DESCRIPTION
- Stats: label text reduced from text-sm to text-xs (~15%) so numbers lead
- Hero: added "end-to-end" to clarify operational scope
- Services intro: "Two core services" → "Core services" (removes contradiction)
- FAQ CTA: "No scripts, no hand-offs." → "No scripts. No hand-offs." (cadence)

https://claude.ai/code/session_01TgRZ6Pxu3PRoawqtiGYCjS