### PR TITLE
Stat bar + trust section: spacing, hierarchy, logo sizing

### DIFF
--- a/src/components/home/Stats.tsx
+++ b/src/components/home/Stats.tsx
@@ -7,12 +7,19 @@ import AnimatedCounter from '@/components/ui/AnimatedCounter';
 import { STATS } from '@/lib/data';
 import { getIcon } from '@/lib/icons';
 
+const clarifications: Record<string, string> = {
+  'Active Call Centre Agents': 'Pretoria-based, full-time',
+  'Outbound Calls Made': 'Across active client campaigns',
+  'Leads Processed': 'Qualified and routed to sales',
+  'Rands in Recurring Collections': 'Monthly recovered revenue',
+};
+
 export default function Stats() {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: '-50px' });
 
   return (
-    <section ref={ref} className="bg-navy pt-10 pb-14 lg:pt-12 lg:pb-16">
+    <section ref={ref} className="bg-navy pt-12 pb-14 lg:pt-14 lg:pb-16">
       <Container>
         <div className="grid grid-cols-2 gap-8 lg:grid-cols-4 lg:gap-12">
           {STATS.map((stat, i) => {
@@ -32,7 +39,10 @@ export default function Stats() {
                     suffix={stat.suffix}
                   />
                 </div>
-                <p className="mt-2 text-xs text-slate-400">{stat.label}</p>
+                <p className="mt-3 text-xs text-slate-500">{stat.label}</p>
+                {clarifications[stat.label] && (
+                  <p className="mt-1 text-[10px] text-slate-600">{clarifications[stat.label]}</p>
+                )}
               </motion.div>
             );
           })}
@@ -41,7 +51,7 @@ export default function Stats() {
           initial={{ opacity: 0 }}
           animate={isInView ? { opacity: 1 } : {}}
           transition={{ duration: 0.6, delay: 0.5 }}
-          className="mt-8 text-center text-xs text-slate-500"
+          className="mt-10 text-center text-[11px] text-slate-600"
         >
           Across subscription, fundraising, and outbound sales campaigns
         </motion.p>

--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -5,11 +5,11 @@ import { useRef } from 'react';
 import Container from '@/components/ui/Container';
 
 const clients = [
-  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png' },
-  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png' },
-  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png' },
-  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png' },
-  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png' },
+  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', desktopH: 'h-12 lg:h-14', mobileH: 'h-10' },
+  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-12 lg:h-14', mobileH: 'h-10' },
+  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[53px] lg:h-[62px]', mobileH: 'h-[44px]' },
+  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[53px] lg:h-[62px]', mobileH: 'h-[44px]' },
+  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png', desktopH: 'h-12 lg:h-14', mobileH: 'h-10' },
 ];
 
 export default function TrustBar() {
@@ -17,7 +17,7 @@ export default function TrustBar() {
   const isInView = useInView(ref, { once: true, margin: '-50px' });
 
   return (
-    <section ref={ref} className="bg-navy pt-14 lg:pt-16 pb-0">
+    <section ref={ref} className="bg-navy pt-14 lg:pt-16 pb-10 lg:pb-12">
       <Container>
         <motion.p
           initial={{ opacity: 0 }}
@@ -29,7 +29,7 @@ export default function TrustBar() {
         </motion.p>
 
         {/* Desktop: single row, large logos */}
-        <div className="hidden sm:flex items-center justify-center gap-14 lg:gap-20">
+        <div className="hidden sm:flex items-center justify-center gap-16 lg:gap-24">
           {clients.map((client, i) => (
             <motion.div
               key={client.name}
@@ -41,7 +41,7 @@ export default function TrustBar() {
               <img
                 src={client.src}
                 alt={client.name}
-                className="h-12 lg:h-14 w-auto max-w-[180px] object-contain brightness-0 invert opacity-80"
+                className={`${client.desktopH} w-auto max-w-[180px] object-contain brightness-0 invert opacity-80`}
               />
             </motion.div>
           ))}
@@ -60,12 +60,15 @@ export default function TrustBar() {
               <img
                 src={client.src}
                 alt={client.name}
-                className="h-10 w-auto max-w-full object-contain brightness-0 invert opacity-80"
+                className={`${client.mobileH} w-auto max-w-full object-contain brightness-0 invert opacity-80`}
               />
             </motion.div>
           ))}
         </div>
       </Container>
+
+      {/* Visual separator between logos and stats */}
+      <div className="mt-10 lg:mt-12 border-t border-slate-700/30" />
     </section>
   );
 }

--- a/src/components/ui/AnimatedCounter.tsx
+++ b/src/components/ui/AnimatedCounter.tsx
@@ -43,7 +43,7 @@ export default function AnimatedCounter({
 
   return (
     <span ref={ref} className="tabular-nums">
-      {prefix}{count}{suffix}
+      {prefix}{count}<span className="text-[0.7em] font-semibold">{suffix}</span>
     </span>
   );
 }


### PR DESCRIPTION
Stats:
- Labels reduced to text-slate-500 (lower contrast vs white numbers)
- Suffix (+, K+, M+) rendered at 0.7em to stay subordinate to numbers
- Added per-stat operational clarification line (10px, slate-600)
- Increased number-to-label spacing (mt-2 → mt-3)
- Increased spacing to supporting line (mt-8 → mt-10)
- Top padding increased for breathing room from trust section

Trust section:
- Added pb-10/pb-12 bottom padding (was pb-0)
- Added border-t separator between logos and stats
- Desktop gap increased from gap-14/gap-20 to gap-16/gap-24
- Firearms Guardian logo +10% (h-[53px]/h-[62px])
- Acorn Brokers logo +10% (h-[53px]/h-[62px])
- Per-logo height classes for consistent visual weight

https://claude.ai/code/session_01TgRZ6Pxu3PRoawqtiGYCjS