### PR TITLE
Update logo URLs and apply navbar logo styling

### DIFF
--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -9,7 +9,7 @@ const clients = [
   { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
   { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
   { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
-  { name: 'Civil Society SA', src: 'https://civilsociety.lovable.app/assets/logo-Czk94Wx-.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'Civil Society SA', src: 'https://i.ibb.co/ZRtZ9gq5/New-Project-96.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
 ];
 
 export default function TrustBar() {

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -38,6 +38,7 @@ export default function Navbar() {
               src={LOGO_URL}
               alt="SIG Solutions"
               className="h-[60px]"
+              style={{ filter: 'brightness(0) saturate(100%) invert(14%) sepia(42%) saturate(4618%) hue-rotate(193deg) brightness(89%) contrast(98%)' }}
             />
           </Link>
 


### PR DESCRIPTION
## Summary
Updated the Civil Society SA logo URL in the TrustBar component and applied a CSS filter to the navbar logo for improved visual consistency.

## Changes
- **TrustBar.tsx**: Replaced the Civil Society SA logo URL from `civilsociety.lovable.app` to `i.ibb.co` (image hosting service)
- **Navbar.tsx**: Added a CSS filter style to the navbar logo to adjust its color appearance with brightness, saturation, invert, sepia, hue-rotate, and contrast adjustments

## Implementation Details
The navbar logo filter applies a color transformation that shifts the logo to a blue tone while maintaining visibility. This ensures consistent branding across different sections of the application.

https://claude.ai/code/session_013wrAFKwUT3BpNrFU7oTZVf