### PR TITLE
Increase Civil Society logo display size for square image

### DIFF
--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -9,7 +9,7 @@ const clients = [
   { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
   { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
   { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
-  { name: 'Civil Society SA', src: 'https://i.ibb.co/ZRtZ9gq5/New-Project-96.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'Civil Society SA', src: 'https://i.ibb.co/ZRtZ9gq5/New-Project-96.png', desktopH: 'h-[72px] lg:h-[88px]', mobileH: 'h-16' },
 ];
 
 export default function TrustBar() {


### PR DESCRIPTION
The new logo is 176x176 (square) — bump height to 72px/88px desktop and 16 mobile so it renders at full size alongside the wider logos.

https://claude.ai/code/session_013wrAFKwUT3BpNrFU7oTZVf