### PR TITLE
Fix cropped Civil Society logo: update URL and remove max-w constraint

### DIFF
--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -9,7 +9,7 @@ const clients = [
   { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
   { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
   { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
-  { name: 'Civil Society SA', src: 'https://i.ibb.co/ZRtZ9gq5/New-Project-96.png', desktopH: 'h-[72px] lg:h-[88px]', mobileH: 'h-16' },
+  { name: 'Civil Society SA', src: 'https://i.postimg.cc/brgFFL5N/New-Project-(96).png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
 ];
 
 export default function TrustBar() {
@@ -41,7 +41,7 @@ export default function TrustBar() {
               <img
                 src={client.src}
                 alt={client.name}
-                className={`${client.desktopH} w-auto max-w-[200px] object-contain brightness-0 invert opacity-90`}
+                className={`${client.desktopH} w-auto object-contain brightness-0 invert opacity-90`}
               />
             </motion.div>
           ))}


### PR DESCRIPTION
The max-w-[200px] was clipping the wider logo image. Removed the width cap so logos size naturally from their height + w-auto. Also switched to the correct postimg.cc URL.

https://claude.ai/code/session_013wrAFKwUT3BpNrFU7oTZVf