### PR TITLE
Add 3 new client logos and reduce Free SA logo size by 25%

### DIFF
--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -6,10 +6,13 @@ import Container from '@/components/ui/Container';
 
 const clients = [
   { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
-  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-12 lg:h-[54px]', mobileH: 'h-9' },
   { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
   { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
   { name: 'Civil Society SA', src: 'https://i.postimg.cc/brgFFL5N/New-Project-(96).png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'MyLawyer', src: 'https://mylawyer.co.za/wp-content/uploads/2020/09/MyLawyer-Hires-logo2.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'Capital Legacy', src: 'https://docs.capitallegacy.co.za/images/CL-Brand-Logo.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'TTC', src: 'https://static.wixstatic.com/media/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png/v1/fit/w_2500,h_1330,al_c/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
 ];
 
 export default function TrustBar() {
@@ -29,7 +32,7 @@ export default function TrustBar() {
         </motion.p>
 
         {/* Desktop: single row, larger logos with improved contrast */}
-        <div className="hidden sm:flex items-center justify-center gap-16 lg:gap-24">
+        <div className="hidden sm:flex items-center justify-center flex-wrap gap-10 lg:gap-16">
           {clients.map((client, i) => (
             <motion.div
               key={client.name}


### PR DESCRIPTION
- Add MyLawyer, Capital Legacy, and TTC client logos
- Shrink Free South Africa logo by 25% (h-16/72px → h-12/54px)
- Reduce desktop gaps and add flex-wrap to fit 8 logos cleanly

https://claude.ai/code/session_013wrAFKwUT3BpNrFU7oTZVf