### PR TITLE
Convert client logos to infinite-scroll carousel and shrink MyLawyer

### DIFF
--- a/src/components/home/TrustBar.tsx
+++ b/src/components/home/TrustBar.tsx
@@ -5,14 +5,14 @@ import { useRef } from 'react';
 import Container from '@/components/ui/Container';
 
 const clients = [
-  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
-  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', desktopH: 'h-12 lg:h-[54px]', mobileH: 'h-9' },
-  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
-  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', desktopH: 'h-[68px] lg:h-[80px]', mobileH: 'h-14' },
-  { name: 'Civil Society SA', src: 'https://i.postimg.cc/brgFFL5N/New-Project-(96).png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
-  { name: 'MyLawyer', src: 'https://mylawyer.co.za/wp-content/uploads/2020/09/MyLawyer-Hires-logo2.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
-  { name: 'Capital Legacy', src: 'https://docs.capitallegacy.co.za/images/CL-Brand-Logo.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
-  { name: 'TTC', src: 'https://static.wixstatic.com/media/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png/v1/fit/w_2500,h_1330,al_c/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png', desktopH: 'h-16 lg:h-[72px]', mobileH: 'h-12' },
+  { name: 'TLU', src: 'https://www.tlu.co.za/wp-content/uploads/2021/07/Logo2025.png', h: 'h-12 sm:h-16 lg:h-[72px]' },
+  { name: 'Free South Africa', src: 'https://www.freesa.org.za/wp-content/uploads/2022/07/Free-SA_Logo_Main.png', h: 'h-9 sm:h-12 lg:h-[54px]' },
+  { name: 'Firearms Guardian', src: 'https://firearmsguardian.co.za/wp-content/uploads/2023/12/Firearms-Guardian-Logo_Firearms-Guardian-Web-1536x941.png', h: 'h-14 sm:h-[68px] lg:h-[80px]' },
+  { name: 'Acorn Brokers', src: 'https://acornbrokers.co.za/images/logo.png', h: 'h-14 sm:h-[68px] lg:h-[80px]' },
+  { name: 'Civil Society SA', src: 'https://i.postimg.cc/brgFFL5N/New-Project-(96).png', h: 'h-12 sm:h-16 lg:h-[72px]' },
+  { name: 'MyLawyer', src: 'https://mylawyer.co.za/wp-content/uploads/2020/09/MyLawyer-Hires-logo2.png', h: 'h-9 sm:h-12 lg:h-[54px]' },
+  { name: 'Capital Legacy', src: 'https://docs.capitallegacy.co.za/images/CL-Brand-Logo.png', h: 'h-12 sm:h-16 lg:h-[72px]' },
+  { name: 'TTC', src: 'https://static.wixstatic.com/media/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png/v1/fit/w_2500,h_1330,al_c/1c17fd_07f39f5fc19140a685334d8ef9771c0e~mv2.png', h: 'h-12 sm:h-16 lg:h-[72px]' },
 ];
 
 export default function TrustBar() {
@@ -30,45 +30,29 @@ export default function TrustBar() {
         >
           Trusted by organisations running high-volume outbound, fundraising, and recurring collections
         </motion.p>
-
-        {/* Desktop: single row, larger logos with improved contrast */}
-        <div className="hidden sm:flex items-center justify-center flex-wrap gap-10 lg:gap-16">
-          {clients.map((client, i) => (
-            <motion.div
-              key={client.name}
-              initial={{ opacity: 0, y: 10 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
-              className="flex items-center justify-center px-2"
-            >
-              <img
-                src={client.src}
-                alt={client.name}
-                className={`${client.desktopH} w-auto object-contain brightness-0 invert opacity-90`}
-              />
-            </motion.div>
-          ))}
-        </div>
-
-        {/* Mobile: 2 per row */}
-        <div className="grid grid-cols-2 gap-8 sm:hidden">
-          {clients.map((client, i) => (
-            <motion.div
-              key={client.name}
-              initial={{ opacity: 0, y: 10 }}
-              animate={isInView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.4, delay: 0.1 + i * 0.1 }}
-              className="flex items-center justify-center px-2 py-2"
-            >
-              <img
-                src={client.src}
-                alt={client.name}
-                className={`${client.mobileH} w-auto max-w-full object-contain brightness-0 invert opacity-90`}
-              />
-            </motion.div>
-          ))}
-        </div>
       </Container>
+
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={isInView ? { opacity: 1 } : {}}
+        transition={{ duration: 0.6, delay: 0.2 }}
+        className="overflow-hidden"
+      >
+        <div className="flex animate-scroll items-center gap-12 sm:gap-16 lg:gap-20 hover:[animation-play-state:paused]">
+          {[...clients, ...clients].map((client, i) => (
+            <div
+              key={`${client.name}-${i}`}
+              className="flex shrink-0 items-center justify-center px-2"
+            >
+              <img
+                src={client.src}
+                alt={client.name}
+                className={`${client.h} w-auto object-contain brightness-0 invert opacity-90`}
+              />
+            </div>
+          ))}
+        </div>
+      </motion.div>
     </section>
   );
 }


### PR DESCRIPTION
- Replaced separate desktop/mobile layouts with a single-line auto-scrolling carousel using the existing animate-scroll keyframe
- Logos duplicated for seamless infinite loop (translateX -50%)
- Pauses on hover for usability
- MyLawyer logo reduced 25% (h-16/72px → h-12/54px)
- Responsive heights via unified h class per logo

https://claude.ai/code/session_013wrAFKwUT3BpNrFU7oTZVf